### PR TITLE
[#28] Fix - Add Imaginary Solution to Quadratic Eqn calculator

### DIFF
--- a/script.js
+++ b/script.js
@@ -281,7 +281,15 @@ const solutionEq = () =>{
 
     var disc = ((b*b) - (4*a*c));
     if(disc<0){
-        document.getElementById('resultEqn').innerHTML = `The equation has no real solution` ;
+        var discRoot = Math.sqrt(-disc);
+        var sol_real = ((-b)/(2*a));
+        var sol_img = ((discRoot)/(2*a));
+        var resSol_real = sol_real.toFixed(2);
+        var resSol_img = sol_img.toFixed(4);
+        var resSol1 = '(' + resSol_real + ' + i ' + resSol_img + ')';
+        var resSol2 = '(' + resSol_real + ' - i ' + resSol_img + ')';
+        document.getElementById('resultEqn').innerHTML = `Solutions are ${resSol1} & ${resSol2}` ;
+
     } else{
         var discRoot = Math.sqrt(disc);
         var sol1 = ((-b+discRoot)/(2*a));


### PR DESCRIPTION
In script.js:
Update solutionEq. Modify script to get imaginary solution with i notation when the discriminant is negative for a given set of input for a, b, c.

Closes https://github.com/Srijita-Mandal/fix-your-nums/issues/28 by adding imaginary solution to improve Quadratic Eqn calculator.

![Fix](https://i.imgur.com/T3RASXJ.png)